### PR TITLE
nrsysmond.cfg should be considered as sensitive

### DIFF
--- a/providers/server_monitor.rb
+++ b/providers/server_monitor.rb
@@ -45,6 +45,7 @@ def install_newrelic_service_linux
     variables(
       :resource => new_resource
     )
+    sensitive true # Important to ensure License Key is not logged during Chef run
     notifies new_resource.service_notify_action, "service[#{new_resource.service_name}]"
   end
   service new_resource.service_name do


### PR DESCRIPTION
At the moment the nrsysmond.cfg is not considered as a sensitive template, so the License Key is actually logged during Chef convergence. This fix will prevent that. However, it does mean we will not be able to see any other change taking place on the file.